### PR TITLE
Use entry_points to configure PyXLL

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -33,3 +33,7 @@ install_requires =
 
 [options.package_data]
 * = *.ico
+
+[options.entry_points]
+pyxll =
+    modules = vnpy_excelrtd:pyxll_modules

--- a/vnpy_excelrtd/__init__.py
+++ b/vnpy_excelrtd/__init__.py
@@ -36,3 +36,10 @@ class ExcelRtdApp(BaseApp):
     engine_class: RtdEngine = RtdEngine
     widget_name: str = "RtdManager"
     icon_name: str = str(app_path.joinpath("ui", "rtd.ico"))
+
+
+def pyxll_modules():
+    """Return a list of modules for PyXLL to import on startup."""
+    return [
+        "vnpy_excelrtd.vnpy_rtd"
+    ]

--- a/vnpy_excelrtd/vnpy_rtd.py
+++ b/vnpy_excelrtd/vnpy_rtd.py
@@ -61,7 +61,7 @@ class RtdClient(RpcClient):
         self.rtds: Dict[str, Set[ObjectRtd]] = defaultdict(set)
 
         global rtd_client
-        rtd_client: RtdClient = self
+        rtd_client = self
 
     def callback(self, topic: str, data: Any) -> None:
         """"""
@@ -95,7 +95,7 @@ class RtdClient(RpcClient):
 def init_client() -> None:
     """Initialize vnpy rtd client"""
     global rtd_client
-    rtd_client: RtdClient = RtdClient()
+    rtd_client = RtdClient()
     rtd_client.subscribe_topic("")
     rtd_client.start(REQ_ADDRESS, SUB_ADDRESS)
 


### PR DESCRIPTION
By using entry points, PyXLL can be told what modules to import on startup. This avoids the user having to manually configure their pyxll.cfg file to include this module.

Also fixed an import error due to a global variable with a local type annotation, which is not permitted.